### PR TITLE
fix deprecated yaml.load call without Loader argument

### DIFF
--- a/services/gcp_add_deployment/run.py
+++ b/services/gcp_add_deployment/run.py
@@ -221,11 +221,11 @@ class ServiceRunner(ServiceTemplate):
             return template_in_yaml
 
 
-        self.deployment_template = _add_agent_installation(yaml.load(self.input['deployment_template']))
+        self.deployment_template = _add_agent_installation(yaml.load(self.input['deployment_template'], Loader=yaml.SafeLoader))
         self.deployment_import_templates = []
 
         if self.input['deployment_import_templates']:
-            for name, content in yaml.load(self.input['deployment_import_templates']).items():
+            for name, content in yaml.load(self.input['deployment_import_templates'], Loader=yaml.SafeLoader).items():
                 content = _add_agent_installation(content)
                 entry = {
                     "name": name,


### PR DESCRIPTION
Starting with pyyaml 6.0, `yaml.load` must take a `Loader` argument.

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
https://github.com/yaml/pyyaml/releases/tag/6.0

